### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository provides a Model Context Protocol (MCP) server that offers sever
 
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/ceshine-git-prompts-mcp-server-badge.png)](https://mseep.ai/app/ceshine-git-prompts-mcp-server)
 
+<a href="https://glama.ai/mcp/servers/@ceshine/git-prompts-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ceshine/git-prompts-mcp-server/badge" alt="Git Prompts Server MCP server" />
+</a>
+
 [![Tests](https://github.com/ceshine/git-prompts-mcp-server/actions/workflows/run_tests.yml/badge.svg)](https://github.com/ceshine/git-prompts-mcp-server/actions/workflows/run_tests.yml)
 
 ## Acknowledgements


### PR DESCRIPTION
This PR adds a badge for the [Git Prompts MCP Server](https://glama.ai/mcp/servers/@ceshine/git-prompts-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ceshine/git-prompts-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ceshine/git-prompts-mcp-server/badge" alt="Git Prompts Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.